### PR TITLE
Fix investor transaction amount calculations

### DIFF
--- a/src/mappings/services/investorTransactionService.ts
+++ b/src/mappings/services/investorTransactionService.ts
@@ -7,9 +7,6 @@ const currencyTypes = [
   InvestorTransactionType.INVEST_ORDER_CANCEL,
   InvestorTransactionType.INVEST_EXECUTION,
   InvestorTransactionType.REDEEM_COLLECT,
-]
-
-const tokenTypes = [
   InvestorTransactionType.REDEEM_ORDER_UPDATE,
   InvestorTransactionType.REDEEM_ORDER_CANCEL,
   InvestorTransactionType.REDEEM_EXECUTION,
@@ -17,6 +14,8 @@ const tokenTypes = [
   InvestorTransactionType.TRANSFER_IN,
   InvestorTransactionType.TRANSFER_OUT,
 ]
+
+const tokenTypes = []
 
 export interface InvestorTransactionData {
   readonly poolId: string


### PR DESCRIPTION
When querying `investorTransactions` all of the transactions that were considered `tokenTypes` were returning numbers far too small to be realistic (usually zero). By moving all to the `currencyTypes` the amounts were calculated properly again. Seems to me that the events actually always return the `tokenAmount` and therefore it must always be converted into the `currencyAmount`

TODO:
- fix tests