### PR TITLE
fix: enable query aggregate for deployments

### DIFF
--- a/.github/workflows/subql_deploy_workflow.yaml
+++ b/.github/workflows/subql_deploy_workflow.yaml
@@ -116,6 +116,7 @@ jobs:
           --disableHistorical \
           --indexerVersion="$SUBQL_INDEXER_VERSION" \
           --queryVersion="$SUBQL_QUERY_VERSION"
+          --queryAggregate
       # - name: Deploy ETH Version
       #   run: |
       #     npx subql deployment:deploy \


### PR DESCRIPTION
`queryAggregate` enabled on recommendation from subql team. The flag allows us to query like this
```gql
query {
    poolSnapshots {
      nodes {
         pool {
          currency {
            decimals
          }
        }
      }
    }
  }
```

Without the flag, the query only returns the poolId.