### PR TITLE
Update chainId after RU

### DIFF
--- a/chains-cfg/development.yaml
+++ b/chains-cfg/development.yaml
@@ -1,7 +1,7 @@
 name: 'pools-development' #CHANGE ME BASED ON SUBQL DEPLOYMENT
 network:
   endpoint: wss://fullnode.development.cntrfg.com
-  chainId: '0x27d6bdae3ea8fc7021792f3ccea5ee62fee37641c6f69d6e8530cfb45ef57a64'
+  chainId: '0xc787b4dfaa5c0b163fa24eeeb8bf2d06188f81c1beb7ebea76e581549f55254d'
   chaintypes:
     file: ./dist/chaintypes.js
 dataSources:


### PR DESCRIPTION
Seeing this errors:
```
{"level":"error","timestamp":"2024-06-23T14:16:37.561Z","pid":7,"hostname":"subquery-21106-indexer-deployment-5cbfcf9db9-mdjbt","category":"api","message":"Failed to init wss://fullnode.development.cntrfg.com: Error: Value of ChainId does not match across all endpoints\n\n       Expected: 0x27d6bdae3ea8fc7021792f3ccea5ee62fee37641c6f69d6e8530cfb45ef57a64\n       Actual: 0xc787b4dfaa5c0b163fa24eeeb8bf2d06188f81c1beb7ebea76e581549f55254d"}
{"level":"error","timestamp":"2024-06-23T14:16:37.561Z","pid":7,"hostname":"subquery-21106-indexer-deployment-5cbfcf9db9-mdjbt","category":"subql-node","payload":
```

And consequently: 
```
{"type":"error","name":"Error","message":"Node failed to start","stack":"Error: Node failed to start\n    at bootstrap (/dist/init.js:36:40)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","cause":{"type":"error","name":"Error","message":"All endpoints failed to initialize. Please add healthier endpoints","stack":"Error: All endpoints failed to initialize. Please add healthier endpoints\n    at ApiService.createConnections (/node_modules/@subql/node-core/dist/api.service.js:81:19)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ApiService.init (/dist/indexer/api.service.js:128:9)\n    at async bootstrap (/dist/init.js:28:9)"}}}
```

Probably because of the ChainID, the subquery node fails to start and its therefore unavailable, hopefully this PR changes that